### PR TITLE
Make compatible with Mediawiki version 1.42

### DIFF
--- a/src/ResourceModule/Base.php
+++ b/src/ResourceModule/Base.php
@@ -15,7 +15,7 @@ use RuntimeException;
  * Even better: The custom RL classes in this extension should not build on
  * \ResourceLoaderFileModule but on \ResourceLoaderModule
  */
-class Base extends \ResourceLoaderFileModule {
+class Base extends \MediaWiki\ResourceLoader\FileModule {
 
 	/**
 	 * Gets all scripts for a given context concatenated together.


### PR DESCRIPTION
1.42 contains a breaking change with the ResourceLoader class https://www.mediawiki.org/wiki/Release_notes/1.42